### PR TITLE
formato per sendRaw(), macro, dim. buffer messaggi

### DIFF
--- a/receiver/.gitignore
+++ b/receiver/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+secrets.h

--- a/receiver/lib/Utils/Utils.cpp
+++ b/receiver/lib/Utils/Utils.cpp
@@ -1,0 +1,19 @@
+#include <WString.h>
+#include "Utils.hpp"
+
+
+String uint16ArrayToString(uint16_t array[], uint16_t length) {
+
+    String res = String(length) + "|";
+    
+    for (uint16_t i = 0; i < length; i++){
+        
+        res += String(array[i]);
+        
+        if (i != length-1) {
+            res += ",";
+        }
+    }
+
+    return res;
+}

--- a/receiver/lib/Utils/Utils.hpp
+++ b/receiver/lib/Utils/Utils.hpp
@@ -1,0 +1,17 @@
+#ifndef Utils_h
+#define Utils_h
+
+#include <WString.h>
+
+/**
+ * Dato un array di uint16 e la sua dimensione 
+ * restituisce una String nel formato:
+ * "<length>|<array[0]>,<array[1]>,..."
+ * 
+ * @param array Insieme valori letti dal sensore IR
+ * @param length Lunghezza di array
+ * @return Stringa con formato "<length>|<array[0]>,<array[1]>,..."
+*/
+String uint16ArrayToString(uint16_t array[], uint16_t length);
+
+#endif // Utils_h

--- a/receiver/src/main.hpp
+++ b/receiver/src/main.hpp
@@ -1,0 +1,15 @@
+#ifndef Main_h
+#define Main_h
+
+#include <WString.h>
+
+#define RECV_PIN 14           // su Node MCU e' il Pin D5
+
+void connect_wifi();
+void setDateTime();
+void connect_mqtt();
+void send_ir_msg(String value);
+void setup();
+void loop();
+
+#endif // Main_h

--- a/receiver/src/secrets.h.sample
+++ b/receiver/src/secrets.h.sample
@@ -1,0 +1,6 @@
+#define WIFI_SSID "<WiFi SSID>"
+#define WIFI_PASS "<WiFi password>"
+#define MQTT_SERVER "<HiveMQ MQTT URL>"
+#define MQTT_USER "<HiveMQ MQTT username>"
+#define MQTT_PASS "<HiveMQ MQTT password>"
+#define MQTT_CLIENT_ID "IREXTENDER - Transmitter"


### PR DESCRIPTION
* Invio dati nel formato "<length>|<val1>,<val2>,..." per permettere la trasmissione del segnale IR con sendRaw()
* Rimosso buffer per il messaggio
* Rese variabili SSID, password, url, ... Macro da definire nel file secrets.h
* Specificata dimensione buffer dei messaggi MQTT per permettere l'invio delle stringhe con il formato specificato al primo punto